### PR TITLE
Add logic for skipping collapsed regions. Fixes #2

### DIFF
--- a/ScrollWithStationaryCursor/Commands.cs
+++ b/ScrollWithStationaryCursor/Commands.cs
@@ -11,6 +11,7 @@ namespace ScrollWithStationaryCursor
     {
         private const int UpCommandId = 0x0100, DownCommandId = 0x0101;
         private const int VerticalScrollBar = 1;
+        private const int RegionPlaceholderWidth = 23;
         
         private readonly AsyncPackage package;
         
@@ -59,13 +60,55 @@ namespace ScrollWithStationaryCursor
             var textManager = (IVsTextManager2)ServiceProvider.GetService(typeof(SVsTextManager));
             if ((textManager != null)
                 && (textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var view) == VSConstants.S_OK)
-                && (view.GetScrollInfo(VerticalScrollBar, out int min, out int max, out int visibleLines, out int top) == VSConstants.S_OK)
-                && ((direction > 0) || (top > 0))
-                && (view.GetCaretPos(out int caretLine, out int caretColumn) == VSConstants.S_OK)
-                && ((direction < 0) || (caretLine < max)))
+                && (view.GetScrollInfo(VerticalScrollBar, out int _min, out int _max, out int _visibleLines, out int top) == VSConstants.S_OK)
+                && ((direction == 1) || (top > 0))
+                && (view.GetCaretPos(out int currentCaretLine, out int currentCaretColumn) == VSConstants.S_OK))
             {
-                view.SetScrollPosition(VerticalScrollBar, top + direction);
-                view.SetCaretPos(caretLine + direction, caretColumn);
+                var currentLinePoint = new Microsoft.VisualStudio.OLE.Interop.POINT[1];
+                view.GetPointOfLineColumn(currentCaretLine, currentCaretColumn, currentLinePoint);
+
+                void TestLine(int line, out bool isValid, out bool isInsideCollapsedRegion)
+                {
+                    var linePoint = new Microsoft.VisualStudio.OLE.Interop.POINT[1];
+                    isValid = view.GetPointOfLineColumn(line, currentCaretColumn, linePoint) == VSConstants.S_OK;
+                    isInsideCollapsedRegion = isValid && (linePoint[0].x != currentLinePoint[0].x) && (Math.Abs(linePoint[0].x - currentLinePoint[0].x) != RegionPlaceholderWidth);
+                }
+
+                int potentialNextCaretLine = currentCaretLine + direction;
+                TestLine(potentialNextCaretLine, out bool isPotentialNextCaretLineValid, out bool isPotentialNextCaretLineInsideRegion);
+                if (!isPotentialNextCaretLineValid)
+                    return;
+
+                int nextCaretLine, nextCaretColumn;
+                if (!isPotentialNextCaretLineInsideRegion)
+                {
+                    nextCaretLine = potentialNextCaretLine;
+                    nextCaretColumn = currentCaretColumn;
+                }
+                else
+                {
+                    potentialNextCaretLine = currentCaretLine;
+                    bool isCaretLineInsideRegion;
+                    do
+                    {
+                        int nextCaretLineToTest = potentialNextCaretLine + direction;
+                        TestLine(nextCaretLineToTest, out bool isCaretLineValid, out isCaretLineInsideRegion);
+                        if (!isCaretLineValid)
+                            break;
+
+                        potentialNextCaretLine = nextCaretLineToTest;
+                    }
+                    while ((potentialNextCaretLine > 0) && isCaretLineInsideRegion);
+                    nextCaretLine = potentialNextCaretLine;
+                    nextCaretColumn = isCaretLineInsideRegion ? 0 : currentCaretColumn;
+                }
+
+                bool didCaretMove = nextCaretLine != currentCaretLine;
+                if (didCaretMove)
+                {
+                    view.SetCaretPos(nextCaretLine, nextCaretColumn);
+                    view.SetScrollPosition(VerticalScrollBar, top + direction);
+                }
             }
         }
     }


### PR DESCRIPTION
It seems the VisualStudio Interop API does not provide access to the region-info. The only way I could find to work around this is to determine if we're inside of a collapsed region based on the horizontal screen position of the caret. It turns out strange things happen to the caret's horizontal screen position if it's inside of a collapsed region, and we can exploit this :P

The strategy is to skip lines (upwards or downwards) until we find we are no longer inside of a collapsed region.