### PR TITLE
Add logic for skipping collapsed regions. Fixes #2

### DIFF
--- a/ScrollWithStationaryCursor/Commands.cs
+++ b/ScrollWithStationaryCursor/Commands.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
 using System;
 using System.ComponentModel.Design;
+using System.Linq;
 using Task = System.Threading.Tasks.Task;
 
 namespace ScrollWithStationaryCursor
@@ -11,6 +13,8 @@ namespace ScrollWithStationaryCursor
     {
         private const int UpCommandId = 0x0100, DownCommandId = 0x0101;
         private const int VerticalScrollBar = 1;
+        private const int DirectionUp = -1, DirectionDown = 1;
+        private const int PlaceholderWidthInCharacters = 3;
         
         private readonly AsyncPackage package;
         
@@ -45,13 +49,13 @@ namespace ScrollWithStationaryCursor
         private void ExecuteUp(object sender, EventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            Scroll(-1);
+            Scroll(DirectionUp);
         }
 
         private void ExecuteDown(object sender, EventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            Scroll(1);
+            Scroll(DirectionDown);
         }
 
         private void Scroll(int direction)
@@ -59,14 +63,137 @@ namespace ScrollWithStationaryCursor
             var textManager = (IVsTextManager2)ServiceProvider.GetService(typeof(SVsTextManager));
             if ((textManager != null)
                 && (textManager.GetActiveView2(1, null, (uint)_VIEWFRAMETYPE.vftCodeWindow, out var view) == VSConstants.S_OK)
-                && (view.GetScrollInfo(VerticalScrollBar, out int min, out int max, out int visibleLines, out int top) == VSConstants.S_OK)
-                && ((direction > 0) || (top > 0))
-                && (view.GetCaretPos(out int caretLine, out int caretColumn) == VSConstants.S_OK)
-                && ((direction < 0) || (caretLine < max)))
+                && (view.GetScrollInfo(VerticalScrollBar, out int _, out int _, out int _, out int top) == VSConstants.S_OK)
+                && (view.GetCaretPos(out int caretLine, out int caretColumn) == VSConstants.S_OK))
             {
+                int nextLine = caretLine + direction;
+                int nextColumn = caretColumn;
+                bool isNextLineValid = ((direction == DirectionUp) && (top > 0))
+                    || ((direction == DirectionDown) && (view.GetPointOfLineColumn(nextLine, nextColumn, new Microsoft.VisualStudio.OLE.Interop.POINT[1]) == VSConstants.S_OK));
+                if (!isNextLineValid)
+                    return;
+
+                if (SkipCollapsedRegionForCaretToTheRightOfCollapsedRegion(view, direction, caretLine, caretColumn, out int nextLineForCase1, out int nextColumnForCase1))
+                {
+                    nextLine = nextLineForCase1;
+                    nextColumn = nextColumnForCase1;
+                }
+                else if (SkipCollapsedRegion(view, direction, caretLine, caretColumn, out int nextLineForCase2, out int nextColumnForCase2))
+                {
+                    nextLine = nextLineForCase2;
+                    nextColumn = nextColumnForCase2;
+                }
+
                 view.SetScrollPosition(VerticalScrollBar, top + direction);
-                view.SetCaretPos(caretLine + direction, caretColumn);
+                view.SetCaretPos(nextLine, nextColumn);
             }
+        }
+
+        private static bool SkipCollapsedRegionForCaretToTheRightOfCollapsedRegion(
+            IVsTextView view, int direction, int caretLine, int caretColumn, out int nextLine, out int nextColumn)
+        {
+            nextLine = 0;
+            nextColumn = 0;
+            if ((view.GetNearestPosition(caretLine, caretColumn, out int caretPosition, out int _) != VSConstants.S_OK) || (caretPosition == 0))
+                return false;
+
+            var textViewManager = TextViewManager.Instance;
+            var outliningManager = textViewManager.GetOutliningManager(textViewManager.ActiveTextView);
+            var textSnapshot = textViewManager.ActiveTextView.TextSnapshot;
+
+            var leftOfCaretPositionPoint = new SnapshotPoint(textSnapshot, caretPosition - 1);
+            var leftOfCaretPositionSpan = textViewManager.ActiveTextView.GetTextElementSpan(leftOfCaretPositionPoint);
+            var collapsedRegion = outliningManager.GetCollapsedRegions(leftOfCaretPositionSpan).FirstOrDefault();
+            if (collapsedRegion == null)
+                return false;
+
+            var endPoint = collapsedRegion.Extent.GetEndPoint(textSnapshot);
+            bool caretIsAtTheEndOfCollapsedRegion = endPoint.Position == caretPosition;
+            if (!caretIsAtTheEndOfCollapsedRegion)
+                return false;
+
+            if (view.GetLineAndColumn(endPoint.Position, out int regionEndLine, out int _) != VSConstants.S_OK)
+                return false;
+
+            bool regionEndsAtEndOfLine =
+                (view.GetLineAndColumn(endPoint.Position + 2, out int lineOfPositionAfterRegionEnd, out int _) == VSConstants.S_OK)
+                && (lineOfPositionAfterRegionEnd > regionEndLine);
+            if (!regionEndsAtEndOfLine)
+                return false;
+
+            var startPoint = collapsedRegion.Extent.GetStartPoint(textSnapshot);
+            if (view.GetLineAndColumn(startPoint.Position, out int regionStartLine, out int regionStartColumn) != VSConstants.S_OK)
+                return false;
+
+            nextLine = direction == DirectionDown ? caretLine + 1 : regionStartLine - 1;
+            nextColumn = regionStartColumn + PlaceholderWidthInCharacters;
+            return true;
+        }
+
+        private static bool SkipCollapsedRegion(
+            IVsTextView view, int direction, int caretLine, int caretColumn, out int nextLine, out int nextColumn)
+        {
+            nextLine = caretLine + direction;
+            nextColumn = caretColumn;
+            if (view.GetNearestPosition(nextLine, nextColumn, out int nextPosition, out int _) != VSConstants.S_OK)
+                return false;
+
+            var textViewManager = TextViewManager.Instance;
+            var outliningManager = textViewManager.GetOutliningManager(textViewManager.ActiveTextView);
+            var textSnapshot = textViewManager.ActiveTextView.TextSnapshot;
+
+            var nextPositionPoint = new SnapshotPoint(textSnapshot, nextPosition);
+            var nextPositionSpan = textViewManager.ActiveTextView.GetTextElementSpan(nextPositionPoint);
+            var collapsedRegion = outliningManager.GetCollapsedRegions(nextPositionSpan).FirstOrDefault();
+            if (collapsedRegion == null)
+                return false;
+
+            var startPoint = collapsedRegion.Extent.GetStartPoint(textSnapshot);
+            var endPoint = collapsedRegion.Extent.GetEndPoint(textSnapshot);
+            if ((view.GetLineAndColumn(startPoint.Position, out int regionStartLine, out int regionStartColumn) != VSConstants.S_OK)
+                || (view.GetLineAndColumn(endPoint.Position, out int regionEndLine, out int regionEndColumn) != VSConstants.S_OK))
+            {
+                return false;
+            }
+
+            bool RegionEndsAtEndOfLine()
+            {
+                return (view.GetLineAndColumn(endPoint.Position + 2, out int lineOfPositionAfterRegionEnd, out int _) == VSConstants.S_OK)
+                    && (lineOfPositionAfterRegionEnd > regionEndLine);
+            }
+
+            if (direction == DirectionUp)
+            {
+                if (regionStartColumn >= caretColumn)
+                {
+                    nextLine = regionStartLine;
+                }
+                else if (RegionEndsAtEndOfLine())
+                {
+                    nextLine = regionEndLine;
+                    nextColumn = regionEndColumn;
+                }
+                else
+                {
+                    nextLine = regionStartLine - 1;
+                }
+            }
+            else // Down
+            {
+                bool regionStartsToTheRightOfCaret = caretLine == regionStartLine;
+                if (regionStartsToTheRightOfCaret)
+                {
+                    nextLine = regionEndLine + 1;
+                }
+                else
+                {
+                    nextLine = regionEndLine;
+                    if (RegionEndsAtEndOfLine())
+                        nextColumn = regionEndColumn;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/ScrollWithStationaryCursor/EditorClassifier/ClassificationDefinition.cs
+++ b/ScrollWithStationaryCursor/EditorClassifier/ClassificationDefinition.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+
+namespace ScrollWithStationaryCursor.EditorClassifier
+{
+    internal static class ClassificationDefinition
+    {
+#pragma warning disable 169
+        [Export(typeof(ClassificationTypeDefinition))]
+        [Name(nameof(EditorClassifier))]
+        private static ClassificationTypeDefinition typeDefinition;
+#pragma warning restore 169
+    }
+}

--- a/ScrollWithStationaryCursor/EditorClassifier/EditorClassifier.cs
+++ b/ScrollWithStationaryCursor/EditorClassifier/EditorClassifier.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+
+namespace ScrollWithStationaryCursor.EditorClassifier
+{
+    internal class EditorClassifier : IClassifier
+    {
+        private readonly IClassificationType classificationType;
+
+        internal EditorClassifier(IClassificationTypeRegistryService registry)
+        {
+            this.classificationType = registry.GetClassificationType(nameof(EditorClassifier));
+        }
+
+#pragma warning disable 67
+        public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged;
+#pragma warning restore 67
+
+        public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span)
+        {
+            return new List<ClassificationSpan>()
+            {
+                new ClassificationSpan(new SnapshotSpan(span.Snapshot, new Span(span.Start, span.Length)), this.classificationType)
+            };
+        }
+    }
+}

--- a/ScrollWithStationaryCursor/EditorClassifier/Provider.cs
+++ b/ScrollWithStationaryCursor/EditorClassifier/Provider.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+
+namespace ScrollWithStationaryCursor.EditorClassifier
+{
+    [Export(typeof(IClassifierProvider))]
+    [ContentType("text")]
+    internal class Provider : IClassifierProvider
+    {
+#pragma warning disable 649
+        [Import]
+        private IClassificationTypeRegistryService classificationRegistry;
+#pragma warning restore 649
+
+        public IClassifier GetClassifier(ITextBuffer buffer)
+        {
+            return buffer.Properties.GetOrCreateSingletonProperty(creator: () => new EditorClassifier(this.classificationRegistry));
+        }
+    }
+}

--- a/ScrollWithStationaryCursor/ScrollWithStationaryCursor.csproj
+++ b/ScrollWithStationaryCursor/ScrollWithStationaryCursor.csproj
@@ -56,11 +56,16 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="EditorClassifier\EditorClassifier.cs" />
+    <Compile Include="EditorClassifier\ClassificationDefinition.cs" />
+    <Compile Include="EditorClassifier\Provider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Commands.cs" />
     <Compile Include="Package.cs" />
+    <Compile Include="TextViewManager.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Key.snk" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
@@ -89,7 +94,7 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.0.26228\lib\net45\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.CoreUtility.15.8.525\lib\net46\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Imaging.15.0.26228\lib\net45\Microsoft.VisualStudio.Imaging.dll</HintPath>
@@ -132,30 +137,54 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.Shell.Interop.9.0.9.0.30729\lib\Microsoft.VisualStudio.Shell.Interop.9.0.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.Data.15.8.525\lib\net46\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.Logic.15.8.525\lib\net46\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.UI.15.8.525\lib\net46\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Text.UI.Wpf.15.8.525\lib\net46\Microsoft.VisualStudio.Text.UI.Wpf.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.7.10.6070\lib\Microsoft.VisualStudio.TextManager.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Threading.15.3.23\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.Utilities.15.0.26228\lib\net46\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.0.82\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="Package.vsct">

--- a/ScrollWithStationaryCursor/TextViewManager.cs
+++ b/ScrollWithStationaryCursor/TextViewManager.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Outlining;
+using Microsoft.VisualStudio.Utilities;
+using System;
+using System.ComponentModel.Composition;
+
+namespace ScrollWithStationaryCursor
+{
+    [Export(typeof(ITextViewCreationListener))]
+    [ContentType("text")]
+    [TextViewRole(PredefinedTextViewRoles.Document)]
+    internal class TextViewManager : ITextViewCreationListener
+    {
+        public static TextViewManager Instance { get; private set; }
+
+#pragma warning disable 649
+        [Import]
+        private IOutliningManagerService outliningManagerService;
+#pragma warning restore 649
+
+        private TextViewManager()
+        {
+            Instance = this;
+        }
+
+        public ITextView ActiveTextView { get; private set; }
+
+        public IOutliningManager GetOutliningManager(ITextView textView)
+        {
+            return this.outliningManagerService.GetOutliningManager(textView);
+        }
+
+        public void TextViewCreated(ITextView textView)
+        {
+            ActiveTextView = textView;
+            textView.GotAggregateFocus += TextView_GotAggregateFocus;
+            textView.Closed += TextView_Closed;
+        }
+
+        private void TextView_GotAggregateFocus(object sender, EventArgs e)
+        {
+            ActiveTextView = (ITextView)sender;
+        }
+
+        private void TextView_Closed(object sender, EventArgs e)
+        {
+            var textView = (ITextView)sender;
+            textView.GotAggregateFocus -= TextView_GotAggregateFocus;
+            textView.Closed -= TextView_Closed;
+        }
+    }
+}

--- a/ScrollWithStationaryCursor/app.config
+++ b/ScrollWithStationaryCursor/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.3.0.0" newVersion="15.3.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/ScrollWithStationaryCursor/packages.config
+++ b/ScrollWithStationaryCursor/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26228" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.8.525" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging" version="15.0.26228" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.25408" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6071" targetFramework="net46" />
@@ -15,11 +15,17 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" version="14.3.25407" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Interop.8.0" version="8.0.50727" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="15.8.525" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="15.8.525" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="15.8.525" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Text.UI.Wpf" version="15.8.525" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.3.23" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Threading.Analyzers" version="15.8.168" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Utilities" version="15.0.26228" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.8.3253" targetFramework="net46" developmentDependency="true" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/ScrollWithStationaryCursor/source.extension.vsixmanifest
+++ b/ScrollWithStationaryCursor/source.extension.vsixmanifest
@@ -17,5 +17,6 @@
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+      <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
Use the IOutlineManager to get the start and end positions of the region that the caret is moving into in order to skip over them.