### PR TITLE
Fix minimum version of Visual Studio in vsixmanifest

### DIFF
--- a/ScrollWithStationaryCursor.VS2019/source.extension.vsixmanifest
+++ b/ScrollWithStationaryCursor.VS2019/source.extension.vsixmanifest
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ScrollWithStationaryCursor.6c6fa4d2-b436-43e3-b155-ed8379a68744" Version="2.0" Language="en-US" Publisher="Bernhard Häussermann" />
+        <Identity Id="ScrollWithStationaryCursor.6c6fa4d2-b436-43e3-b155-ed8379a68744" Version="2.0.1" Language="en-US" Publisher="Bernhard Häussermann" />
         <DisplayName>Scroll with Stationary Cursor</DisplayName>
         <Description xml:space="preserve">Adds commands that allow to scroll up or down in the text editor while having the (keyboard) cursor move along.</Description>
     </Metadata>
     <Installation>
-		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)">
+		<InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.10, 17.0)">
 			<ProductArchitecture>x86</ProductArchitecture>
 		</InstallationTarget>
     </Installation>
@@ -14,7 +14,7 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0, 17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.10, 17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />

--- a/ScrollWithStationaryCursor.VS2022/source.extension.vsixmanifest
+++ b/ScrollWithStationaryCursor.VS2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ScrollWithStationaryCursor.VS2022.6c6fa4d2-b436-43e3-b155-ed8379a68744" Version="2.0" Language="en-US" Publisher="Bernhard Häussermann" />
+        <Identity Id="ScrollWithStationaryCursor.VS2022.6c6fa4d2-b436-43e3-b155-ed8379a68744" Version="2.0.1" Language="en-US" Publisher="Bernhard Häussermann" />
         <DisplayName>Scroll with Stationary Cursor</DisplayName>
         <Description xml:space="preserve">Adds commands that allow to scroll up or down in the text editor while having the (keyboard) cursor move along.</Description>
     </Metadata>


### PR DESCRIPTION
Set minimum version of Visual Studio to be 16.10 for the VS 2019 version of the extension. Fixes #5